### PR TITLE
Fix crash in AgoraRtcEngine destructor (Qt Demo)

### DIFF
--- a/agora-demo-qt/agorartcengine.h
+++ b/agora-demo-qt/agorartcengine.h
@@ -48,7 +48,7 @@ public slots:
 private:
     friend class AgoraRtcEngineEvent;
 private:
-    std::unique_ptr<agora::rtc::IRtcEngine> m_rtcEngine;
+    agora::util::AutoPtr<agora::rtc::IRtcEngine> m_rtcEngine;
     std::unique_ptr<agora::rtc::IRtcEngineEventHandler> m_eventHandler;
 };
 


### PR DESCRIPTION
The `m_rtcEngine` in `AgoraRtcEngine` is allocated by agora API `createAgoraRtcEngine()` and should be freed by `IRtcEngine::release()`. However the `std::unique_ptr` trys to free it by `delete`, thus causing crash. By replacing `std::unique_ptr` to `agora::util::AutoPtr`, this issue is fixed.